### PR TITLE
Load initial password from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 2. Build the solution: `msbuild projectbaluga.sln` (or `dotnet build` with the appropriate SDK).
 3. Run `projectbaluga.exe`; `projectbaluga.dll` must reside alongside the executable.
 
+### Initial Password
+
+On first run the application looks for an environment variable named `PROJECTBALUGA_INITIAL_PASSWORD`. If present, its value is used as the initial administrator password and stored securely. When the variable is absent the application will prompt for a password and require one to be set before continuing.
+
 ## Repository Layout
 
 - `projectbaluga/` – WPF application source.

--- a/projectbaluga/MainWindow.xaml.cs
+++ b/projectbaluga/MainWindow.xaml.cs
@@ -34,6 +34,17 @@ namespace projectbaluga
         public MainWindow()
         {
             InitializeComponent();
+            if (!Security.PasswordStore.IsPasswordSet)
+            {
+                MessageBox.Show("No admin password found. Please set a password to continue.", "Security", MessageBoxButton.OK, MessageBoxImage.Warning);
+                var settingsWindow = new SettingsWindow();
+                settingsWindow.ShowDialog();
+                if (!Security.PasswordStore.IsPasswordSet)
+                {
+                    Application.Current.Shutdown();
+                    return;
+                }
+            }
             ValidateUrls();
             InitializeWebView2();
             ShowDesktopIcons();

--- a/projectbaluga/Security/PasswordStore.cs
+++ b/projectbaluga/Security/PasswordStore.cs
@@ -9,6 +9,7 @@ namespace projectbaluga.Security
     {
         private static readonly string StorePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "projectbaluga", "admin.pass");
+        private const string InitialPasswordEnvVar = "PROJECTBALUGA_INITIAL_PASSWORD";
         private const int SaltSize = 16;
         private const int HashSize = 32;
         private const int Iterations = 100000;
@@ -20,9 +21,15 @@ namespace projectbaluga.Security
                 Directory.CreateDirectory(dir);
             if (!File.Exists(StorePath))
             {
-                SetPassword("amiralakbar");
+                var initialPassword = Environment.GetEnvironmentVariable(InitialPasswordEnvVar);
+                if (!string.IsNullOrWhiteSpace(initialPassword))
+                {
+                    SetPassword(initialPassword);
+                }
             }
         }
+
+        public static bool IsPasswordSet => File.Exists(StorePath);
 
         public static void SetPassword(string password)
         {


### PR DESCRIPTION
## Summary
- Read default admin password from the `PROJECTBALUGA_INITIAL_PASSWORD` environment variable instead of using a hard-coded value
- Prompt user to set a password at startup when none is configured
- Document initial password setup via environment variable