### PR TITLE
Toggle shutdown timeout field via auto shutdown setting

### DIFF
--- a/projectbaluga/SettingsWindow.xaml
+++ b/projectbaluga/SettingsWindow.xaml
@@ -58,7 +58,7 @@
                 <CheckBox x:Name="AutoShutdownCheckBox"
               Foreground="#333333"
               Content="Auto Shutdown&#xD;&#xA;"
-              FontSize="14" Checked="AutoShutdownCheckBox_Checked" Height="18" Width="130" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,0,0,0"/>
+              FontSize="14" Checked="AutoShutdownCheckBox_Checked" Unchecked="AutoShutdownCheckBox_Checked" Height="18" Width="130" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,0,0,0"/>
             </StackPanel>
 
             <Button Content="Save" HorizontalAlignment="Stretch"

--- a/projectbaluga/SettingsWindow.xaml.cs
+++ b/projectbaluga/SettingsWindow.xaml.cs
@@ -26,6 +26,8 @@ namespace projectbaluga
             TopmostCheckBox.IsChecked = Properties.Settings.Default.IsTopmost;
             ShutdownTimeoutBox.Text = Properties.Settings.Default.ShutdownTimeoutMinutes.ToString();
             AutoShutdownCheckBox.IsChecked = Properties.Settings.Default.EnableAutoShutdown;
+            // Initialize the shutdown timeout box state based on the auto-shutdown setting
+            ShutdownTimeoutBox.IsEnabled = AutoShutdownCheckBox.IsChecked == true;
 
         }
 
@@ -84,7 +86,8 @@ namespace projectbaluga
 
         private void AutoShutdownCheckBox_Checked(object sender, RoutedEventArgs e)
         {
-
+            // Enable the timeout box only when auto shutdown is enabled
+            ShutdownTimeoutBox.IsEnabled = AutoShutdownCheckBox.IsChecked == true;
         }
         public int ShutdownTimeoutMinutes
         {


### PR DESCRIPTION
## Summary
- Enable or disable the shutdown timeout box based on the auto-shutdown checkbox
- Invoke the same handler on checkbox uncheck to keep the field state synced with the setting