### PR TITLE
Avoid watchdog shutdown on admin unlock

### DIFF
--- a/projectbaluga/MainWindow.xaml.cs
+++ b/projectbaluga/MainWindow.xaml.cs
@@ -187,12 +187,8 @@ namespace projectbaluga
 
             if (result == true && projectbaluga.Security.PasswordStore.VerifyPassword(passwordDialog.Password))
             {
-                Application.Current.Shutdown();
                 CancelShutdownCountdown();
-            }
-            else
-            {
-                Close();
+                OpenSettings();
             }
 
             this.IsEnabled = true;


### PR DESCRIPTION
## Summary
- Prevent the app from shutting down when the correct admin password is entered
- Keep the kiosk running if the unlock dialog is cancelled or the password is incorrect