### PR TITLE
Add log rotation and project contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to projectbaluga
+
+Thank you for considering contributing to `projectbaluga`!
+
+## Getting Started
+
+1. Fork the repository and create your feature branch from `main`.
+2. Ensure you have the .NET Framework 4.7.2 SDK and WebView2 runtime installed.
+3. Build the solution:
+
+   ```sh
+   dotnet build
+   ```
+
+## Making Changes
+
+- Follow existing code style and naming conventions.
+- Include tests or manual verification steps where applicable.
+- Run `dotnet build` before submitting a pull request.
+
+## Submitting a Pull Request
+
+1. Commit your changes with clear, descriptive messages.
+2. Push to your fork and open a pull request against the `main` branch.
+3. Describe your changes and include any testing steps performed.
+
+We appreciate your contributions to the project!
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 projectbaluga contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/projectbaluga/PasswordDialog.xaml.cs
+++ b/projectbaluga/PasswordDialog.xaml.cs
@@ -11,6 +11,7 @@ namespace projectbaluga
         private static int failedAttempts = 0;
         private static DateTime lockoutEnd = DateTime.MinValue;
         private static readonly string logPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "projectbaluga", "unlock.log");
+        private const long MaxLogSizeBytes = 1 * 1024 * 1024; // 1 MB
 
         public PasswordDialog()
         {
@@ -84,6 +85,24 @@ namespace projectbaluga
             {
                 Directory.CreateDirectory(dir);
             }
+
+            try
+            {
+                if (File.Exists(logPath) && new FileInfo(logPath).Length > MaxLogSizeBytes)
+                {
+                    var archivePath = logPath + ".1";
+                    if (File.Exists(archivePath))
+                    {
+                        File.Delete(archivePath);
+                    }
+                    File.Move(logPath, archivePath);
+                }
+            }
+            catch (IOException)
+            {
+                // Ignore rotation failures
+            }
+
             File.AppendAllText(logPath, $"{DateTime.Now:u} - {(success ? "Success" : "Fail")}{Environment.NewLine}");
         }
     }


### PR DESCRIPTION
## Summary
- prevent unlock log from growing indefinitely by rotating at 1MB
- add MIT license and basic contribution guidelines