### PR TITLE
Add .NET Framework reference assemblies to legacy project

### DIFF
--- a/projectbaluga/packages.config
+++ b/projectbaluga/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Web.WebView2" version="1.0.2849.39" targetFramework="net472" />
+  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.3" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/projectbaluga/projectbaluga.csproj
+++ b/projectbaluga/projectbaluga.csproj
@@ -187,10 +187,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2849.39\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2849.39\build\Microsoft.Web.WebView2.targets')" />
+  <Import Project="..\packages\Microsoft.NETFramework.ReferenceAssemblies.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.targets" Condition="Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2849.39\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2849.39\build\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NETFramework.ReferenceAssemblies.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- ensure .NET Framework reference assemblies are available by adding Microsoft.NETFramework.ReferenceAssemblies package
- wire up reference assembly targets in project file