### PR TITLE
Fix unlock dialog opening settings instead of unlocking

### DIFF
--- a/projectbaluga/MainWindow.xaml.cs
+++ b/projectbaluga/MainWindow.xaml.cs
@@ -193,7 +193,9 @@ namespace projectbaluga
             if (result == true && projectbaluga.Security.PasswordStore.VerifyPassword(passwordDialog.Password))
             {
                 CancelShutdownCountdown();
-                OpenSettings();
+                currentState = AppState.LoggedIn;
+                UpdateKeyboardHookState();
+                HandlePostLogin();
             }
 
             this.IsEnabled = true;


### PR DESCRIPTION
## Summary
- Fix Unlock button to correctly transition the application to a logged-in state instead of showing Settings