### PR TITLE
Hide WebView during fallback to display offline message

### DIFF
--- a/projectbaluga/MainWindow.xaml.cs
+++ b/projectbaluga/MainWindow.xaml.cs
@@ -342,6 +342,10 @@ namespace projectbaluga
                 {
                     StatusText.Text = status ?? string.Empty;
                 }
+                if (webView2 != null)
+                {
+                    webView2.Visibility = show ? Visibility.Collapsed : Visibility.Visible;
+                }
             }
         }
         private bool IsInternetAvailable()


### PR DESCRIPTION
## Summary
- collapse WebView2 control when showing offline fallback to avoid blank blank screen