### PR TITLE
Use dedicated fallback XAML window

### DIFF
--- a/projectbaluga/FallbackWindow.xaml
+++ b/projectbaluga/FallbackWindow.xaml
@@ -1,0 +1,35 @@
+<Window x:Class="projectbaluga.FallbackWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Fallback"
+        ShowInTaskbar="False"
+        WindowState="Maximized" WindowStyle="None" ResizeMode="NoResize"
+        Background="Black">
+    <Grid>
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+            <TextBlock Text="No network connection"
+                       Foreground="White"
+                       FontSize="32"
+                       FontWeight="Bold"
+                       TextAlignment="Center"
+                       Margin="0,0,0,10"/>
+            <TextBlock x:Name="FallbackMessage"
+                       Foreground="White"
+                       FontSize="16"
+                       TextAlignment="Center"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,20">
+                Please check your LAN cable or Wi-Fi settings. If the problem persists, contact the BOJEX TEAM.
+            </TextBlock>
+            <TextBlock x:Name="StatusText"
+                       Foreground="White"
+                       FontSize="14"
+                       TextAlignment="Center"
+                       Margin="0,0,0,20"/>
+            <Button Content="Retry"
+                    Width="100"
+                    HorizontalAlignment="Center"
+                    Click="OnRetryClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/projectbaluga/FallbackWindow.xaml.cs
+++ b/projectbaluga/FallbackWindow.xaml.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Windows;
+
+namespace projectbaluga
+{
+    public partial class FallbackWindow : Window
+    {
+        public event RoutedEventHandler RetryRequested;
+
+        public FallbackWindow()
+        {
+            InitializeComponent();
+        }
+
+        public void SetStatus(string status)
+        {
+            StatusText.Text = status ?? string.Empty;
+        }
+
+        private void OnRetryClicked(object sender, RoutedEventArgs e)
+        {
+            RetryRequested?.Invoke(sender, e);
+        }
+    }
+}

--- a/projectbaluga/MainWindow.xaml
+++ b/projectbaluga/MainWindow.xaml
@@ -19,33 +19,5 @@
             </StackPanel>
         </ScrollViewer>
 
-        <!-- Fallback overlay shown when no network connection is available -->
-        <Grid x:Name="FallbackGrid" Background="Black" Visibility="Collapsed">
-            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="No network connection"
-                           Foreground="White"
-                           FontSize="32"
-                           FontWeight="Bold"
-                           TextAlignment="Center"
-                           Margin="0,0,0,10"/>
-                <TextBlock x:Name="FallbackMessage"
-                           Foreground="White"
-                           FontSize="16"
-                           TextAlignment="Center"
-                           TextWrapping="Wrap"
-                           Margin="0,0,0,20">
-                    Please check your LAN cable or Wi-Fi settings. If the problem persists, contact the BOJEX TEAM.
-                </TextBlock>
-                <TextBlock x:Name="StatusText"
-                           Foreground="White"
-                           FontSize="14"
-                           TextAlignment="Center"
-                           Margin="0,0,0,20"/>
-                <Button Content="Retry"
-                        Width="100"
-                        HorizontalAlignment="Center"
-                        Click="RetryConnectivity_Click"/>
-            </StackPanel>
-        </Grid>
     </Grid>
 </Window>

--- a/projectbaluga/MainWindow.xaml.cs
+++ b/projectbaluga/MainWindow.xaml.cs
@@ -26,6 +26,7 @@ namespace projectbaluga
         private string PostLoginUrl => Properties.Settings.Default.PostLoginUrl;
         private string LockScreenUrl => Properties.Settings.Default.LockScreenUrl;
         private HashSet<string> allowedHosts;
+        private FallbackWindow fallbackWindow;
 
         private AppState currentState = AppState.Startup;
         private KeyboardHook keyboardHook;
@@ -61,6 +62,7 @@ namespace projectbaluga
         {
             base.OnClosed(e);
             ProcessWatchdog.Stop();
+            fallbackWindow?.Close();
         }
 
         private void ValidateUrls()
@@ -335,17 +337,22 @@ namespace projectbaluga
 
         private void ShowFallback(bool show, string status = null)
         {
-            if (FallbackGrid != null)
+            if (show)
             {
-                FallbackGrid.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
-                if (show && StatusText != null)
+                if (fallbackWindow == null)
                 {
-                    StatusText.Text = status ?? string.Empty;
+                    fallbackWindow = new FallbackWindow();
+                    fallbackWindow.Owner = this;
+                    fallbackWindow.RetryRequested += RetryConnectivity_Click;
                 }
-                if (webView2 != null)
-                {
-                    webView2.Visibility = show ? Visibility.Collapsed : Visibility.Visible;
-                }
+                fallbackWindow.SetStatus(status);
+                fallbackWindow.Show();
+                this.Hide();
+            }
+            else
+            {
+                fallbackWindow?.Hide();
+                this.Show();
             }
         }
         private bool IsInternetAvailable()

--- a/projectbaluga/projectbaluga.csproj
+++ b/projectbaluga/projectbaluga.csproj
@@ -111,6 +111,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="FallbackWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -119,6 +123,10 @@
     <Compile Include="Security\PasswordStore.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="FallbackWindow.xaml.cs">
+      <DependentUpon>FallbackWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
       <Compile Include="Helpers\DeviceManagerHelper.cs" />


### PR DESCRIPTION
## Summary
- replace in-window network fallback with separate `FallbackWindow`
- show or hide the new window when connectivity changes
- wire up retry button and close logic for new window