### PR TITLE
Ensure settings and password dialogs align with buttons

### DIFF
--- a/projectbaluga/PasswordDialog.xaml
+++ b/projectbaluga/PasswordDialog.xaml
@@ -6,7 +6,7 @@
         WindowStyle="None" ResizeMode="NoResize"
         Background="#FAFAFA">
     <Grid>
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="300" Height="280">
+        <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Center">
             <TextBlock FontWeight="Bold" FontSize="16" Foreground="#333333" HorizontalAlignment="Center" Margin="5,5,5,5" Text="Administrator"/>
 
             <PasswordBox x:Name="PasswordBox" HorizontalAlignment="Stretch" VerticalAlignment="Top"

--- a/projectbaluga/SettingsWindow.xaml
+++ b/projectbaluga/SettingsWindow.xaml
@@ -7,7 +7,7 @@
         WindowStyle="None" ResizeMode="NoResize" Icon="/favicon.ico" Background="#FFFAFAFA">
 
     <Grid HorizontalAlignment="Left" Width="500">
-        <StackPanel HorizontalAlignment="Center" Width="350" Margin="0,0,0,-1">
+        <StackPanel HorizontalAlignment="Stretch" Margin="0,0,0,-1">
             <TextBlock FontWeight="Bold" FontSize="16" Foreground="#333333" HorizontalAlignment="Center" Margin="15,15,15,15">
                 Settings
             </TextBlock>


### PR DESCRIPTION
## Summary
- Let settings window stack panel stretch so save button spans full width
- Allow password dialog stack panel to stretch to window width and content height